### PR TITLE
support optional videoMode params

### DIFF
--- a/syncPlayer.brs
+++ b/syncPlayer.brs
@@ -196,13 +196,11 @@ function createSyncPlayer(_config as Object) as Object
 
   ' Screen resolution settings
   player.videoMode = CreateObject("roVideoMode")
-  if ParseJSON(readasciifile("video.json")) <> invalid then 
-    videoSettings = ParseJSON(ReadAsciiFile("video.json"))
-    if player.videoMode.getMode() <> videoSettings.mode then
-      player.videoMode.setMode(videoSettings.mode)
-      RebootSystem()
-    else 
-      player.videoMode.setMode(videoSettings.mode)
+  videoSettings = ParseJSON(ReadAsciiFile("video.json"))
+  if videoSettings <> invalid and videoSettings.mode <> invalid then
+    if player.videoMode.setMode(videoSettings.mode) = false then
+      print "Invalid video mode '" + videoSettings.mode + "': " + player.videoMode.getFailureReason() + ". Falling back to auto."
+      player.videoMode.setMode("auto")
     end if
   else 
     player.videoMode.setMode("auto")
@@ -1095,6 +1093,7 @@ function injectionPoller()
     end if
   end if
 end function
+
 
 function quit()
   END


### PR DESCRIPTION
currently will get stuck in a boot loop if the mode in video.json is not a valid video mode (for instance "1280x720x60p:420:10bit"), since `player.videoMode.setMode(videoSettings.mode)` will just return false and the mode doesn't change, so the `if player.videoMode.getMode() <> videoSettings.mode` condition will continue to be true on every boot