### PR TITLE
Add gpiotriggered sync mode (GPIO starts playback like follower)

### DIFF
--- a/gpio.brs
+++ b/gpio.brs
@@ -4,24 +4,56 @@ function createGPIOManager(parent)
   gpioManager = createObject("roAssociativeArray")
   gpioManager.parent = parent
   gpioManager.controlPort = createObject("roControlPort", "BrightSign")
-  gpioManager.controlPort.enableInput(1)
   gpioManager.messagePort = createObject("roMessagePort")
   gpioManager.controlPort.setPort(gpioManager.messagePort)
   gpioManager.handle = handleGPIO
+
+  triggerPin = gpioGetTriggerInputPin(parent)
+  if parent.config.syncMode = "gpiotriggered" then
+    gpioManager.controlPort.enableInput(triggerPin)
+    print "gpiotriggered: listening on GPIO input "; triggerPin
+  else
+    gpioManager.controlPort.enableInput(1)
+  end if
 
   return gpioManager
 
 end function
 
+function gpioGetTriggerInputPin(parent as Object) as Integer
+  pin = parent.config.gpioTriggerPin
+  if pin = invalid then
+    return 1
+  end if
+  return cint(pin)
+end function
+
 function handleGPIO()
-  if m.parent.gpioEnabled and m.parent.clock.state = "idle"
-    msg = m.messagePort.GetMessage()
-    if msg <> invalid
-      if type(msg) = "roControlDown"
-        m.parent.subtitler.activate()
-      else if type(msg) = "roControlUp"
-        m.parent.subtitler.deactivate()
+  if not m.parent.gpioEnabled then
+    return
+  end if
+
+  msg = m.messagePort.GetMessage()
+  if msg = invalid then
+    return
+  end if
+
+  if m.parent.config.syncMode = "gpiotriggered" then
+    ' Match follower UDP "start": only begin a new cycle from idle transport.
+    if m.parent.transportState = "idle" then
+      if type(msg) = "roControlDown" and msg.GetInt() = gpioGetTriggerInputPin(m.parent) then
+        print "GPIO trigger: starting playback (gpiotriggered mode)"
+        m.parent.transportState = "starting"
       end if
+    end if
+    return
+  end if
+
+  if m.parent.clock.state = "idle" then
+    if type(msg) = "roControlDown" then
+      m.parent.subtitler.activate()
+    else if type(msg) = "roControlUp" then
+      m.parent.subtitler.deactivate()
     end if
   end if
 end function

--- a/syncPlayer.brs
+++ b/syncPlayer.brs
@@ -165,6 +165,7 @@ function createSyncPlayer(_config as Object) as Object
   else if player.config.syncMode = "solo"
     player.transportState = "starting"
   else 
+    ' follower and gpiotriggered wait for UDP start or GPIO before playing
     player.transportState = "idle"
   end if
 
@@ -322,7 +323,7 @@ function loadVideoFile()
     m.apiRequest.setUrl(m.apiEndpoint.+"/duration")
     updateDurationData = "password="+m.password+"&"
     durationWithDelay = m.duration
-    if m.config.syncMode = "leader" or m.config.syncMode = "follower" then 
+    if m.config.syncMode = "leader" or m.config.syncMode = "follower" or m.config.syncMode = "gpiotriggered" then 
       durationWithDelay = durationWithDelay + m.config.loopPointLeaderDelay
     end if
     updateDurationData = updateDurationData+"duration="+durationWithDelay.toStr()
@@ -349,7 +350,7 @@ function setupUDP()
   if m.config.syncMode = "leader" then
     m.udpSocket.joinMulticastGroup("239.192.1.0")
     m.udpSocket.joinMulticastGroup("239.192.1."+m.config.syncGroup.toStr())
-  else if m.config.syncMode = "follower" then
+  else if m.config.syncMode = "follower" or m.config.syncMode = "gpiotriggered" then
     m.udpSocket.joinMulticastGroup("239.192.2.0")
     m.udpSocket.joinMulticastGroup("239.192.2."+m.config.syncGroup.toStr())
   end if
@@ -845,7 +846,7 @@ function transportMachine()
     m.markLocalStart()
     m.transportState = "submitting timestamp"
   else if m.transportState = "submitting timestamp" then
-    if m.config.syncMode = "follower" then
+    if m.config.syncMode = "follower" or m.config.syncMode = "gpiotriggered" then
       sleep(((m.config.syncGroup+1) MOD 10)*5)
     end if
     if m.config.updateWeb = "on" then
@@ -863,7 +864,7 @@ function transportMachine()
         m.video.seek(0)
         sleep(m.config.loopPointLeaderDelay)
         m.transportState = "starting"
-      else if m.config.syncMode = "follower" then
+      else if m.config.syncMode = "follower" or m.config.syncMode = "gpiotriggered" then
         m.video.pause()
         m.video.seek(0)
         m.transportState = "idle"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds a fourth `syncMode` value, **`gpiotriggered`**, modeled on **follower** behavior: the player stays in `transportState = "idle"` until it should start a cycle, then runs the same play / timestamp / end-of-loop path (including follower multicast groups and the same “pause, seek to 0, return to idle” behavior at the loop point).

The **difference from follower** is the start trigger: instead of relying on a UDP `"start"` message to set `transportState = "starting"`, **`gpiotriggered`** listens for **`roControlDown`** on a configurable GPIO input (default pin **1**, overridable with **`gpioTriggerPin`** in `config.json`).

## Configuration

- `syncMode`: `"gpiotriggered"`
- Optional: `gpioTriggerPin` (integer, default `1`)

## Notes

- In `gpiotriggered` mode, the previous subtitle toggle behavior on GPIO pin 1 is **not** used, so the trigger pin is dedicated to starting playback. Other modes are unchanged.
- GPIO handling follows BrightSign patterns documented for `roControlPort` / `roControlDown` (see BrightDeveloper technical docs on GPIO interactivity).

## Files

- `syncPlayer.brs` — treat `gpiotriggered` like follower for UDP groups, duration delay with `loopPointLeaderDelay`, follower stagger sleep, and end-of-loop idle.
- `gpio.brs` — enable the trigger input and transition to `"starting"` when the configured pin goes down.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f227b4a9-adb6-4c73-b5c6-1966f8ec1660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f227b4a9-adb6-4c73-b5c6-1966f8ec1660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

