### PR TITLE
Add gpiotriggered syncMode — start playback on a GPIO event

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,33 @@ If file should be excluded from the release, add them to the `exclusions` step o
 
 Additionally, there is a file called `ak.features.json` which should be updated with any features from the official [AccessKit build](https://github.com/access-kit/access-kit) which the BrightSign release can make use of.
 
+## Sync Modes
+
+The player supports four `syncMode` values (configured via `config.json`):
+
+- `solo` — the player loops the video on its own (default).
+- `leader` — the player loops the video and broadcasts loop-start UDP messages so `follower`s in its sync group stay in sync.
+- `follower` — the player starts playback each cycle when it receives a UDP `start` message from a `leader` in its sync group.
+- `gpiotriggered` — the player starts playback each cycle when a GPIO input event is received on the configured trigger pin.
+
+## GPIO Configuration
+
+GPIO pins used by the player are configured via `gpio.json`. The file is auto-populated with defaults on first boot if it is missing or invalid:
+
+```json
+{
+  "captionsPin": 1,
+  "triggerPin": 0,
+  "triggerOn": "down"
+}
+```
+
+- `captionsPin` — GPIO input pin that toggles on-screen captions while the player is idle. Defaults to `1` (matches legacy hardcoded behavior).
+- `triggerPin` — GPIO input pin used to start playback when `syncMode` is `gpiotriggered`. Defaults to `0`, intentionally different from `captionsPin` and outside the `2`–`7` range used for timeline-event GPIO outputs.
+- `triggerOn` — `"down"` (default, trigger on button press / `roControlDown`) or `"up"` (trigger on release / `roControlUp`).
+
+Valid pins are `0`–`7`. If `triggerPin` equals `captionsPin`, the GPIO trigger is disabled and a warning is logged (captions wins).
+
 ## Connecting via SSH
 
 `ssh brightsign@ip`

--- a/gpio.brs
+++ b/gpio.brs
@@ -3,8 +3,31 @@ function createGPIOManager(parent)
 
   gpioManager = createObject("roAssociativeArray")
   gpioManager.parent = parent
+
+  ' Load gpio.json with auto-populate of defaults
+  gpioConfig = loadGPIOConfig()
+  gpioManager.captionsPin = gpioConfig.captionsPin
+  gpioManager.triggerPin = gpioConfig.triggerPin
+  gpioManager.triggerOn = gpioConfig.triggerOn
+
+  ' The captions pin always gets wired up. The trigger pin is only wired
+  ' up when the player is in gpiotriggered sync mode AND the pin differs
+  ' from the captions pin (avoid double-purposing a single pin).
+  gpioManager.triggerEnabled = false
+  if parent.config.syncMode = "gpiotriggered"
+    if gpioManager.triggerPin = gpioManager.captionsPin
+      print("WARNING: gpio.json triggerPin ("+gpioManager.triggerPin.toStr()+") is the same as captionsPin; GPIO trigger disabled.")
+    else
+      gpioManager.triggerEnabled = true
+    end if
+  end if
+
   gpioManager.controlPort = createObject("roControlPort", "BrightSign")
-  gpioManager.controlPort.enableInput(1)
+  gpioManager.controlPort.enableInput(gpioManager.captionsPin)
+  if gpioManager.triggerEnabled
+    print("Enabling GPIO trigger input on pin "+gpioManager.triggerPin.toStr()+" with edge "+gpioManager.triggerOn+".")
+    gpioManager.controlPort.enableInput(gpioManager.triggerPin)
+  end if
   gpioManager.messagePort = createObject("roMessagePort")
   gpioManager.controlPort.setPort(gpioManager.messagePort)
   gpioManager.handle = handleGPIO
@@ -13,14 +36,70 @@ function createGPIOManager(parent)
 
 end function
 
+function loadGPIOConfig() as Object
+  defaults = createObject("roAssociativeArray")
+  defaults.addReplace("captionsPin", 1)
+  defaults.addReplace("triggerPin", 0)
+  defaults.addReplace("triggerOn", "down")
+
+  needsWrite = false
+  gpioConfig = ParseJSON(ReadAsciiFile("gpio.json"))
+  if gpioConfig = invalid
+    print("gpio.json missing or unparseable; writing defaults.")
+    gpioConfig = defaults
+    needsWrite = true
+  else
+    ' captionsPin
+    if type(gpioConfig.captionsPin) <> "Integer" or gpioConfig.captionsPin < 0 or gpioConfig.captionsPin > 7
+      print("gpio.json captionsPin invalid; using default 1.")
+      gpioConfig.addReplace("captionsPin", defaults.captionsPin)
+      needsWrite = true
+    end if
+    ' triggerPin
+    if type(gpioConfig.triggerPin) <> "Integer" or gpioConfig.triggerPin < 0 or gpioConfig.triggerPin > 7
+      print("gpio.json triggerPin invalid; using default 0.")
+      gpioConfig.addReplace("triggerPin", defaults.triggerPin)
+      needsWrite = true
+    end if
+    ' triggerOn
+    if gpioConfig.triggerOn <> "down" and gpioConfig.triggerOn <> "up"
+      print("gpio.json triggerOn invalid; using default 'down'.")
+      gpioConfig.addReplace("triggerOn", defaults.triggerOn)
+      needsWrite = true
+    end if
+  end if
+
+  if needsWrite
+    WriteAsciiFile("gpio.json", FormatJSON(gpioConfig))
+  end if
+
+  return gpioConfig
+end function
+
 function handleGPIO()
-  if m.parent.gpioEnabled and m.parent.clock.state = "idle"
+  if m.parent.gpioEnabled
     msg = m.messagePort.GetMessage()
     if msg <> invalid
-      if type(msg) = "roControlDown"
-        m.parent.subtitler.activate()
-      else if type(msg) = "roControlUp"
-        m.parent.subtitler.deactivate()
+      msgType = type(msg)
+      if msgType = "roControlDown" or msgType = "roControlUp"
+        pin = msg.GetInt()
+        if pin = m.captionsPin
+          ' Captions toggle: only while playback is idle (preserves existing behavior).
+          if m.parent.clock.state = "idle"
+            if msgType = "roControlDown"
+              m.parent.subtitler.activate()
+            else
+              m.parent.subtitler.deactivate()
+            end if
+          end if
+        else if m.triggerEnabled and pin = m.triggerPin and m.parent.config.syncMode = "gpiotriggered"
+          triggerEdge = "roControlDown"
+          if m.triggerOn = "up" then triggerEdge = "roControlUp"
+          if msgType = triggerEdge
+            print("GPIO trigger fired on pin "+pin.toStr()+"; moving transport to 'starting'.")
+            m.parent.transportState = "starting"
+          end if
+        end if
       end if
     end if
   end if

--- a/gpio.json
+++ b/gpio.json
@@ -1,0 +1,5 @@
+{
+  "captionsPin": 1,
+  "triggerPin": 0,
+  "triggerOn": "down"
+}

--- a/syncPlayer.brs
+++ b/syncPlayer.brs
@@ -867,6 +867,10 @@ function transportMachine()
         m.video.pause()
         m.video.seek(0)
         m.transportState = "idle"
+      else if m.config.syncMode = "gpiotriggered" then
+        m.video.pause()
+        m.video.seek(0)
+        m.transportState = "idle"
       end if
     end if
   end if


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `syncMode` value, **`gpiotriggered`**, that behaves like `follower` mode (idle at boot, pause + seek(0) + idle at each loop end) **except** the trigger that starts each playback cycle is a GPIO input event rather than a UDP `"start"` broadcast from a leader.

Pin assignments are now configurable through a new `gpio.json` file that auto-populates with defaults on first boot. The captions pin (previously hardcoded to `1`) is also promoted into this file for consistency; its default preserves existing behavior.

## Behavior

| `syncMode` | Start of each cycle |
|---|---|
| `solo` | Self-triggered, seamless loop |
| `leader` | Self-triggered; broadcasts UDP `"start"` to followers |
| `follower` | Receives UDP `"start"` from a leader |
| **`gpiotriggered`** *(new)* | Receives a GPIO input event on the configured trigger pin |

At the end of the video, `gpiotriggered` pauses, seeks to `0`, and returns to `idle` — identical to `follower` — and waits for the next trigger.

## `gpio.json` schema

Auto-populated defaults (written to disk on first boot if the file is missing or invalid):

```json
{
  "captionsPin": 1,
  "triggerPin": 0,
  "triggerOn": "down"
}
```

- **`captionsPin`** *(0–7, default `1`)* — GPIO input that toggles on-screen captions while the player is idle. Default matches the previously hardcoded value, so existing installations see no change in behavior.
- **`triggerPin`** *(0–7, default `0`)* — GPIO input used to start playback when `syncMode = "gpiotriggered"`. Default `0` is intentionally distinct from `captionsPin` (default `1`) and sits outside the `2`–`7` range that `timeline.brs` uses for its GPIO *output* events.
- **`triggerOn`** *(`"down"` | `"up"`, default `"down"`)* — event edge that fires the trigger. `"down"` fires on button press (`roControlDown`); `"up"` fires on release (`roControlUp`).

### Validation

- Any invalid / missing / out-of-range value is replaced with the default and the file is rewritten to disk.
- If `triggerPin = captionsPin`, the GPIO trigger is disabled and a warning is logged — the captions pin wins. This prevents one pin from being double-purposed.

## Files changed

| File | Change |
|---|---|
| `gpio.json` | **New.** Default config shipped with the package. |
| `gpio.brs` | Loads/validates/auto-populates `gpio.json`; enables the trigger input pin only when `syncMode = "gpiotriggered"`; dispatches GPIO events by `msg.GetInt()` pin id so captions and trigger coexist on different pins. |
| `syncPlayer.brs` | One new branch in `transportMachine`'s `waiting to finish` state for `gpiotriggered` (pauses, seeks `0`, returns to `idle`). All other mode-gated paths (`setupUDP`, leader broadcast, duration offset, follower stagger sleep) already skip unknown modes and need no changes. |
| `README.md` | Documents the four sync modes and the `gpio.json` file. |

No changes to `boot.brs`, `timeline.brs`, `subtitler.brs`, `autorun.brs`, `oscBuilder.brs`, `oscParser.brs`, or the release workflow.

## Manual test plan

BrightScript has no on-workstation compile/test step, so these are device-side checks for the reviewer:

1. **Default file creation** — delete `gpio.json` from the SD card, boot. Expect it to be recreated with the defaults above.
2. **Backward compatibility — captions still work** — leave `syncMode = "solo"`, trigger pin 1. Subtitles toggle as today.
3. **Basic gpiotriggered flow** — set `syncMode = "gpiotriggered"` in `config.json`, reboot. Player stays idle. Momentary press on pin 0 → video plays from the beginning. At the end it pauses + returns to idle. Press again → video restarts.
4. **Configurability** — edit `gpio.json` to `triggerPin: 3, triggerOn: "up"`. Reboot. Triggering pin 3 on release starts playback.
5. **Pin conflict safety** — set `triggerPin = captionsPin`. Reboot. Expect a warning in the serial log and trigger to be disabled; captions still toggle.
6. **Mode interoperability** — switch back to `follower`. Captions unchanged; pin 0 is NOT enabled as input (no side effects from presses).
7. **Timeline GPIO output coexistence** — with a timeline event toggling pin 5 output, confirm pin 0 trigger and pin 5 output don't interfere.

## Notes

- The GPIO manager owns its own `roControlPort`, separate from `timeline.brs`'s output-only `roControlPort`. This matches the existing architecture; adding a second input pin to the manager's port is safe per BrightSign's API model.
- `gpio.json` is a local device file (like `window.json`, `audio.json`, `video.json`, `network.json`) and is not synced to / from the AccessKit server.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36110795-692c-4b1e-95c3-c164be1778cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36110795-692c-4b1e-95c3-c164be1778cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

